### PR TITLE
Fix match not defined in master branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Tasks Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Restored the match() function that was incorrectly removed.
+
 ## `0.2.5`
 
 - Fix vulnerabilities in "handlebars" and "mkdirp" dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/tasks-for-zowe-cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Zowe CLI Tasks Plugin",
   "publishConfig": {
     "registry": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/"

--- a/src/api/Action.ts
+++ b/src/api/Action.ts
@@ -468,7 +468,6 @@ export default class Action extends BaseRunner {
         // Create the function
         let func;
         try {
-            // tslint:disable-next-line: function-constructor
             func = new Function(...argNames, this.action.action.run);
         } catch (err) {
             throw new ActionRunException(`Failed to create new js function:\n${err.message}`, this.action);
@@ -569,7 +568,6 @@ export default class Action extends BaseRunner {
             let cont: boolean = true;
             let func;
             try {
-                // tslint:disable-next-line: function-constructor
                 func = new Function(...argNames, this.action.action.run);
             } catch (err) {
                 cont = false;
@@ -579,7 +577,6 @@ export default class Action extends BaseRunner {
             // Create and call the function
             if (cont) {
                 try {
-                    // tslint:disable-next-line: function-constructor
                     func(...argValues);
                 } catch (err) {
                     reject(new ActionRunException(`Function threw an error:\n${err.message}`, this.action));

--- a/src/api/ActionValidator.ts
+++ b/src/api/ActionValidator.ts
@@ -40,9 +40,10 @@ export default class ActionValidator {
  * @param str The string to check for a match.
  * @param regex The regular expression to match.
  *
- * Commented out this unused function
- *
-match(str: string, regex: RegExp): boolean {
+ * This function appears to not be called, but it is
+ * used by the eval() function above.
+ */
+// eslint-disable-next-line unused-imports/no-unused-vars
+function match(str: string, regex: RegExp): boolean {
     return (str.match(regex)) ? true : false;
 }
- */

--- a/src/api/ActionValidator.ts
+++ b/src/api/ActionValidator.ts
@@ -26,7 +26,6 @@ export default class ActionValidator {
     public static evaluate(exp: string, output: any, action: IAction): boolean {
         let result;
         try {
-            // tslint:disable-next-line: no-eval
             result = eval(exp);
         } catch (err) {
             throw new ActionValidatorUnexpectedException(err.message, action);

--- a/src/api/BaseRunner.ts
+++ b/src/api/BaseRunner.ts
@@ -74,7 +74,6 @@ export default abstract class BaseRunner {
     //     const reg = /\${\S+}/g;
     //     let str: string = object[property];
     //     let result;
-    //     // tslint:disable-next-line: no-conditional-assignment
     //     while ((result = reg.exec(str)) !== null) {
     //         for (const prop of Object.keys(this.extractedOutput)) {
     //             if (str.indexOf(`\$\{extracted.${prop}\}`) >= 0) {

--- a/src/api/Config.ts
+++ b/src/api/Config.ts
@@ -274,7 +274,6 @@ export default class Config {
                 } else if (!isNaN(parseInt(value, 10))) {
                     processedValue = parseInt(value, 10);
                 } else if (value === "true" || value === "false") {
-                    // tslint:disable-next-line: triple-equals
                     processedValue = (value == "true");
                 } else {
                     processedValue = value;

--- a/src/api/Utils.ts
+++ b/src/api/Utils.ts
@@ -24,7 +24,6 @@ export default class Utils {
     public static traverse(object: any, substitutions: any, propertyPrefix = "") {
         Object.keys(object).forEach((value) => {
             if (Array.isArray(object[value])) {
-                // tslint:disable-next-line: prefer-for-of
                 for (let x = 0; x < object[value].length; x++) {
                     if (typeof object[value][x] === "object") {
                         Utils.traverse(object[value][x], substitutions, propertyPrefix);
@@ -71,7 +70,6 @@ export default class Utils {
             // Regex is matching on ${<varname>}
             const reg = /\${[^}]+}}?/g;
             let result;
-            // tslint:disable-next-line: no-conditional-assignment
             while ((result = reg.exec(str)) !== null) {
 
                 // Get the property name from the match and get the value for

--- a/src/api/func/WaitForJobStatus.ts
+++ b/src/api/func/WaitForJobStatus.ts
@@ -17,7 +17,6 @@ import { IJob, MonitorJobs, IMonitorJobWaitForParms } from "@zowe/cli";
 export default class WaitForJobStatus extends BaseZosmfFunc {
     protected async execZosmf(params: IFuncParameters, session: Session): Promise<any> {
         const response: IJob = await MonitorJobs.waitForStatusCommon(session as any,
-            // tslint:disable-next-line: no-object-literal-type-assertion
             { ...params.action.args } as IMonitorJobWaitForParms);
         return response;
     }

--- a/src/cli/list.functions.handler.ts
+++ b/src/cli/list.functions.handler.ts
@@ -22,7 +22,6 @@ export default class ExecHandler implements ICommandHandler {
     public async process(params: IHandlerParameters): Promise<void> {
         const keyIter = Functions.BuiltIn.keys();
         let value;
-        // tslint:disable-next-line: no-conditional-assignment
         while ((value = keyIter.next().value) != null) {
             params.response.console.log(value);
         }


### PR DESCRIPTION
Restore the match function which ESLint defined as unused. The project also compiled without match. However, match is called indirectly during expression evaluation.

Also removed all remaining TSLint comments.